### PR TITLE
When configuring IOperables, make the list index accessible

### DIFF
--- a/Source/FizzWare.NBuilder.FunctionalTests/ListBuilderTests.cs
+++ b/Source/FizzWare.NBuilder.FunctionalTests/ListBuilderTests.cs
@@ -330,6 +330,35 @@ namespace FizzWare.NBuilder.FunctionalTests
         }
 
         [Test]
+        public void UsingWith_WithAnIndex()
+        {
+            var invoices = Builder<Product>
+                .CreateListOfSize(2)
+                .TheFirst(2)
+                    .With((p, idx) => p.Description = "Description" + (idx + 5))
+                .Build();
+
+            Assert.That(invoices[0].Description, Is.EqualTo("Description5"));
+            Assert.That(invoices[1].Description, Is.EqualTo("Description6"));
+        }
+
+        [Test]
+        public void UsingAndWithAnIndex()
+        {
+            var invoices = Builder<Product>
+                .CreateListOfSize(2)
+                .TheFirst(2)
+                    .With(p => p.Title = "Title")
+                    .And((p, idx) => p.Description = "Description" + (idx + 5))
+                .Build();
+
+            Assert.That(invoices[0].Title, Is.EqualTo("Title"));
+            Assert.That(invoices[0].Description, Is.EqualTo("Description5"));
+            Assert.That(invoices[1].Title, Is.EqualTo("Title"));
+            Assert.That(invoices[1].Description, Is.EqualTo("Description6"));
+        }
+
+        [Test]
         public void UsingAndWithImmutableClassProperties()
         {
             var invoices = Builder<Invoice>

--- a/Source/FizzWare.NBuilder.Tests/Unit/ObjectBuilderTests.cs
+++ b/Source/FizzWare.NBuilder.Tests/Unit/ObjectBuilderTests.cs
@@ -168,6 +168,25 @@ namespace FizzWare.NBuilder.Tests.Unit
         }
 
         [Test]
+        public void ShouldBeAbleToUseWith_WithAnIndex()
+        {
+            using (mocks.Record())
+            {
+
+            }
+
+            using (mocks.Playback())
+            {
+                var myClass = new MyClass();
+
+                builder.With((x, idx) => x.StringOne = "String" + (idx + 5));
+                builder.CallFunctions(myClass, 9);
+
+                Assert.That(myClass.StringOne, Is.EqualTo("String14"));
+            }
+        }
+
+        [Test]
         public void ShouldBeAbleToUseDo()
         {
             var myClass = MockRepository.GenerateMock<MyClass>();

--- a/Source/FizzWare.NBuilder.Tests/Unit/OperableExtensionTests.cs
+++ b/Source/FizzWare.NBuilder.Tests/Unit/OperableExtensionTests.cs
@@ -41,6 +41,19 @@ namespace FizzWare.NBuilder.Tests.Unit
         }
 
         [Test]
+        public void ShouldBeAbleToUseWith_WithAnIndex()
+        {
+            Action<MyClass, int> funcWithIndex = (x, idx) => x.StringOne = "String" + (idx + 5);
+            using (mocks.Record())
+            {
+                operable.Expect(x => x.ObjectBuilder).Return(new ObjectBuilder<MyClass>(null));
+                objectBuilder.Expect(x => x.With(funcWithIndex));
+            }
+
+            OperableExtensions.With((IOperable<MyClass>)operable, funcWithIndex);
+        }
+
+        [Test]
         public void ShouldBeAbleToUseHas()
         {
             using (mocks.Record())
@@ -62,6 +75,19 @@ namespace FizzWare.NBuilder.Tests.Unit
             }
 
             OperableExtensions.And((IOperable<MyClass>)operable, func);
+        }
+
+        [Test]
+        public void ShouldBeAbleToUseAndWithAnIndex()
+        {
+            Action<MyClass, int> funcWithIndex = (x, idx) => x.StringOne = "String" + (idx + 5);
+            using (mocks.Record())
+            {
+                operable.Expect(x => x.ObjectBuilder).Return(new ObjectBuilder<MyClass>(null));
+                objectBuilder.Expect(x => x.With(funcWithIndex));
+            }
+
+            OperableExtensions.And((IOperable<MyClass>)operable, funcWithIndex);
         }
 
         [Test]

--- a/Source/FizzWare.NBuilder.Tests/Unit/RangeDeclarationTests.cs
+++ b/Source/FizzWare.NBuilder.Tests/Unit/RangeDeclarationTests.cs
@@ -75,7 +75,7 @@ namespace FizzWare.NBuilder.Tests.Unit
                 masterList.Expect(x => x[4]).Return(null);
                 masterList.Expect(x => x[5]).Return(null);
 
-                objectBuilder.Expect(x => x.CallFunctions(null)).IgnoreArguments().Repeat.Times(2);
+                objectBuilder.Expect(x => x.CallFunctions(null, 0)).IgnoreArguments().Repeat.Times(2);
             }
 
             using (mocks.Playback())

--- a/Source/FizzWare.NBuilder/Implementation/Declaration.cs
+++ b/Source/FizzWare.NBuilder/Implementation/Declaration.cs
@@ -89,7 +89,7 @@ namespace FizzWare.NBuilder.Implementation
             for (int i = 0; i < MasterListAffectedIndexes.Count; i++)
             {
                 int index = MasterListAffectedIndexes[i];
-                objectBuilder.CallFunctions(masterList[index]);
+                objectBuilder.CallFunctions(masterList[index], i);
             }
         }
 

--- a/Source/FizzWare.NBuilder/Implementation/IObjectBuilder.cs
+++ b/Source/FizzWare.NBuilder/Implementation/IObjectBuilder.cs
@@ -19,10 +19,12 @@ namespace FizzWare.NBuilder.Implementation
         IObjectBuilder<T> WithConstructorArgs(params object[] args);
 
         IObjectBuilder<T> With<TFunc>(Func<T, TFunc> func);
+        IObjectBuilder<T> With(Action<T, int> action);
         IObjectBuilder<T> Do(Action<T> action);
         IObjectBuilder<T> DoMultiple<TAction>(Action<T, TAction> action, IList<TAction> list);
         IObjectBuilder<T> WithPropertyNamer(IPropertyNamer propertyNamer);
         void CallFunctions(T obj);
+        void CallFunctions(T obj, int objIndex);
         T Construct();
         T Name(T obj);
     }

--- a/Source/FizzWare.NBuilder/Implementation/ObjectBuilder.cs
+++ b/Source/FizzWare.NBuilder/Implementation/ObjectBuilder.cs
@@ -51,6 +51,12 @@ namespace FizzWare.NBuilder.Implementation
             return this;
         }
 
+        public IObjectBuilder<T> With(Action<T, int> func)
+        {
+            functions.Add(func);
+            return this;
+        }
+
         public IObjectBuilder<T> Do(Action<T> action)
         {
             functions.Add(action);
@@ -80,10 +86,24 @@ namespace FizzWare.NBuilder.Implementation
 
         public void CallFunctions(T obj)
         {
+            CallFunctions(obj, 0);
+        }
+
+        public void CallFunctions(T obj, int objIndex)
+        {
             for (int i = 0; i < functions.Count; i++)
             {
                 var del = functions[i];
-                del.DynamicInvoke(obj);
+                int parameterCount = del.Method.GetParameters().Count();
+                switch (parameterCount)
+                {
+                    case 1:
+                        del.DynamicInvoke(obj);
+                        break;
+                    case 2:
+                        del.DynamicInvoke(new object[] { obj, objIndex });
+                        break;
+                }
             }
 
             for (int i = 0; i < multiFunctions.Count; i++)

--- a/Source/FizzWare.NBuilder/OperableExtensions.cs
+++ b/Source/FizzWare.NBuilder/OperableExtensions.cs
@@ -18,6 +18,17 @@ namespace FizzWare.NBuilder
             return (IOperable<T>)declaration;
         }
 
+        /// <summary>
+        /// Sets the value of one of the type's public properties and provides the index of the object being set
+        /// </summary>
+        public static IOperable<T> With<T>(this IOperable<T> operable, Action<T, int> func)
+        {
+            var declaration = GetDeclaration(operable);
+
+            declaration.ObjectBuilder.With(func);
+            return (IOperable<T>)declaration;
+        }
+
         #if OBSOLETE_OLD_SYNTAX
         [Obsolete(Messages.NewSyntax_UseWith)]
         #endif
@@ -52,6 +63,14 @@ namespace FizzWare.NBuilder
         /// Sets the value of one of the type's public properties
         /// </summary>
         public static IOperable<T> And<T, TFunc>(this IOperable<T> operable, Func<T, TFunc> func)
+        {
+            return With(operable, func);
+        }
+
+        /// <summary>
+        /// Sets the value of one of the type's public properties and provides the index of the object being set
+        /// </summary>
+        public static IOperable<T> And<T>(this IOperable<T> operable, Action<T, int> func)
         {
             return With(operable, func);
         }


### PR DESCRIPTION
See the tests for an example.

This resolves Issue 17 (enhancement) from Google Code:
http://code.google.com/p/nbuilder/issues/detail?id=17
