### PR TITLE
* Fix another scenario related to issue #79

### DIFF
--- a/src/FizzWare.NBuilder/Generators/GetRandom.cs
+++ b/src/FizzWare.NBuilder/Generators/GetRandom.cs
@@ -395,7 +395,7 @@ namespace FizzWare.NBuilder.Generators
                 throw new ArgumentException(string.Format("{0} is not an enum type.", type.FullName), "type");
             }
             var values = EnumHelper.GetValues(type);
-            var index = PositiveInt(values.Length - 1);
+            var index = PositiveInt(values.Length);
             return (Enum)values.GetValue(index);
         }   
     }

--- a/tests/FizzWare.NBuilder.Tests/FizzWare.NBuilder.Tests.csproj
+++ b/tests/FizzWare.NBuilder.Tests/FizzWare.NBuilder.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net47;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net47;netcoreapp2.1</TargetFrameworks>
     <AssemblyName>FizzWare.NBuilder.Tests</AssemblyName>
     <RootNamespace>FizzWare.NBuilder.Tests</RootNamespace>
     <Description />

--- a/tests/FizzWare.NBuilder.Tests/Unit/RandomGeneratorTests.cs
+++ b/tests/FizzWare.NBuilder.Tests/Unit/RandomGeneratorTests.cs
@@ -331,6 +331,21 @@ namespace FizzWare.NBuilder.Tests.Unit
             expected.ShouldAllBe(e => actual.Contains(e));
         }
 
+        [Fact]
+        public void GenerateRandomEnumUsingType_ShouldIncludeAllEnumValues()
+        {
+            var expected = Enum.GetValues(typeof(StatusType)).Cast<StatusType>().ToList();
+            var actual = new List<Enum>();
+
+            for (var i = 0; i < 100000; i++)
+            {
+                var statusType = GetRandom.Enumeration(typeof(StatusType));
+                actual.Add(statusType);
+            }
+
+            expected.ShouldAllBe(e => actual.Contains(e));
+        }
+
         [Theory]
         [InlineData(4, 5)]
         [InlineData(16, 20)]


### PR DESCRIPTION
Remove - 1 from the upper bound of the Random() so that the last enum value is included in the `Enum Enumeration(Type type)` method.

EDIT: Also bumps the Test project from .NET Core 1.1 to .NET Core 2.1 since 1.1 is no longer supported and can't be downloaded with VS 2019 Installer.