### PR TITLE
Fix setting public property with private setter #102

### DIFF
--- a/src/FizzWare.NBuilder/Extensions/MemberInfoExtensions.cs
+++ b/src/FizzWare.NBuilder/Extensions/MemberInfoExtensions.cs
@@ -51,7 +51,7 @@ namespace FizzWare.NBuilder.Extensions
             }
             else if (m is PropertyInfo)
             {
-                if (((PropertyInfo)m).CanWrite)
+                if (((PropertyInfo)m).GetSetMethod() != null)
                 {
                     ((PropertyInfo)m).SetValue(instance, value, null);
                 }

--- a/src/FizzWare.NBuilder/PropertyNaming/PropertyNamer.cs
+++ b/src/FizzWare.NBuilder/PropertyNaming/PropertyNamer.cs
@@ -25,7 +25,7 @@ namespace FizzWare.NBuilder.PropertyNaming
         {
             var type = typeof(T);
 
-            foreach (var propertyInfo in type.GetProperties(FLAGS).Where(p => p.CanWrite))
+            foreach (var propertyInfo in type.GetProperties(FLAGS).Where(p => p.GetSetMethod() != null))
                 SetMemberValue(propertyInfo, obj);
 
             foreach (var propertyInfo in type.GetFields(FLAGS).Where(f => !f.IsLiteral))

--- a/src/FizzWare.NBuilder/PropertyNaming/PropertyNamer.cs
+++ b/src/FizzWare.NBuilder/PropertyNaming/PropertyNamer.cs
@@ -98,7 +98,7 @@ namespace FizzWare.NBuilder.PropertyNaming
                     break;
                 case PropertyInfo info:
                     {
-                        if (info.CanWrite)
+                        if (info.GetSetMethod() != null)
                             info.SetValue(obj, value, null);
                         break;
                     }

--- a/src/FizzWare.NBuilder/PropertyNaming/RandomValuePropertyNamer.cs
+++ b/src/FizzWare.NBuilder/PropertyNaming/RandomValuePropertyNamer.cs
@@ -64,7 +64,7 @@ namespace FizzWare.NBuilder.PropertyNaming
 
             for (int i = 0; i < objects.Count; i++)
             {
-                foreach (var propertyInfo in type.GetProperties(FLAGS).Where(p => p.CanWrite))
+                foreach (var propertyInfo in type.GetProperties(FLAGS).Where(p => p.GetSetMethod() != null))
                 {
                     SetMemberValue(propertyInfo, objects[i]);
                 }

--- a/src/FizzWare.NBuilder/PropertyNaming/SequentialPropertyNamer.cs
+++ b/src/FizzWare.NBuilder/PropertyNaming/SequentialPropertyNamer.cs
@@ -25,7 +25,7 @@ namespace FizzWare.NBuilder.PropertyNaming
 
             for (int i = 0; i < objects.Count; i++)
             {
-                foreach (var propertyInfo in type.GetProperties(FLAGS).Where(p => p.CanWrite))
+                foreach (var propertyInfo in type.GetProperties(FLAGS).Where(p => p.GetSetMethod() != null))
                 {
                     SetMemberValue(propertyInfo, objects[i]);
                 }

--- a/tests/FizzWare.NBuilder.Tests/Unit/ObjectBuilderTests.cs
+++ b/tests/FizzWare.NBuilder.Tests/Unit/ObjectBuilderTests.cs
@@ -247,7 +247,7 @@ namespace FizzWare.NBuilder.Tests.Unit
         public class MyTestClassWithPrivateMembers
         {
             private string Fredbob { get; set; }
-
+            
             public string GetFredbob()
             {
                 return Fredbob;
@@ -258,6 +258,23 @@ namespace FizzWare.NBuilder.Tests.Unit
         public void DoesNotSetValueOnPrivateMembers()
         {
             var result = new Builder().CreateNew<MyTestClassWithPrivateMembers>().Build();
+            result.GetFredbob().ShouldBe(null);
+        }
+
+        public class MyTestClassWithPrivateMemberSetters
+        {
+            public string Fredbob { get; private set; }
+
+            public string GetFredbob()
+            {
+                return Fredbob;
+            }
+        }
+
+        [Fact]
+        public void DoesNotSetValueOnPrivateSetterMembers()
+        {
+            var result = new Builder().CreateNew<MyTestClassWithPrivateMemberSetters>().Build();
             result.GetFredbob().ShouldBe(null);
         }
     }


### PR DESCRIPTION
Use GetSetMethod() to discriminate between properties that "can" be written (e.g. public property) and properties that "should" be written (e.g. public property with public getter)