### PR TITLE
Support nullable value types via builder settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ This will create a category tree and by supplying a naming method, will even nam
 
 NBuilder is highly configurable. Through the BuilderSetup class you can control how NBuilder names objects and disable naming for certain properties of certain types.
 
+##### Nullable Value Types
+
+By default, NBuilder will build nullable value types using their non-null equivalent type's default value. Ex: `public int? Foo { get; set; }` will be built as `1` instead of `null`. This can be overriden based on the specific nullable value type, or for all nullable value types.
+
+```c#
+//Set all nullable value types to be built as null
+BuilderSetup.BuildAllNullablePropertiesAsNull();
+```
+
+```c#
+//Specify only specific nullable value types to be built as null
+BuilderSetup.BuildNullablePropertiesAsNullForType(typeof(Guid?), typeof(int?), typeof(double?), typeof(decimal?), typeof(short?));
+```
+
 ##### Custom persistence service
 
 Easily add your own custom persistence service, allowing you to use any `ORM`.

--- a/src/FizzWare.NBuilder/BuilderSettings.cs
+++ b/src/FizzWare.NBuilder/BuilderSettings.cs
@@ -18,6 +18,8 @@ namespace FizzWare.NBuilder
         private IPropertyNamer defaultPropertyNamer;
 
         private List<PropertyInfo> disabledAutoNameProperties;
+        public bool IsBuildingAllNullablePropertiesAsNull { get; internal set; }
+        private List<Type> nullableTypesToBuildAsNull;
 
         internal  bool HasDisabledAutoNameProperties;
 
@@ -33,6 +35,8 @@ namespace FizzWare.NBuilder
             AutoNameProperties = true;
             propertyNamers = new Dictionary<Type, IPropertyNamer>();
             HasDisabledAutoNameProperties = false;
+            IsBuildingAllNullablePropertiesAsNull = false;
+            nullableTypesToBuildAsNull = new List<Type>();
             disabledAutoNameProperties = new List<PropertyInfo>();
         }
 
@@ -80,6 +84,16 @@ namespace FizzWare.NBuilder
         {
             var propertyInfo = GetProperty(func);
             DisablePropertyNamingFor(propertyInfo);
+        }
+
+        internal void BuildNullableTypeAsNull(Type type)
+        {
+            nullableTypesToBuildAsNull.Add(type);
+        }
+
+        internal bool ShouldBuildNullableTypeAsNull(PropertyInfo info)
+        {
+            return nullableTypesToBuildAsNull.Any(x => x == info.PropertyType);
         }
 
         public void DisablePropertyNamingFor(PropertyInfo propertyInfo)

--- a/src/FizzWare.NBuilder/BuilderSetup.cs
+++ b/src/FizzWare.NBuilder/BuilderSetup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using FizzWare.NBuilder.Extensions;
 using FizzWare.NBuilder.PropertyNaming;
 
 namespace FizzWare.NBuilder
@@ -8,6 +9,7 @@ namespace FizzWare.NBuilder
     public static class BuilderSetup
     {
         internal static readonly BuilderSettings Instance =new BuilderSettings();
+        public static bool IsBuildingAllNullablePropertiesAsNull => Instance.IsBuildingAllNullablePropertiesAsNull;
         public static bool AutoNameProperties => Instance.AutoNameProperties;
         //{
         //    get { return Instance.AutoNameProperties; }
@@ -67,7 +69,31 @@ namespace FizzWare.NBuilder
 
         public static void DisablePropertyNamingFor<T, TFunc>(Expression<Func<T,TFunc >> func)
         {
-            Instance.DisablePropertyNamingFor(func);   
+            Instance.DisablePropertyNamingFor(func);
+        }
+
+        /// <summary>
+        /// Set the builder to build all properties that are nullable value types as null instead of the non-null equivalent type's default value.
+        /// </summary>
+        public static void BuildAllNullablePropertiesAsNull()
+        {
+            Instance.IsBuildingAllNullablePropertiesAsNull = true;
+        }
+
+        /// <summary>
+        /// Specify any nullable value types that should be set to null when building instead of the non-null equivalent's default value.
+        /// </summary>
+        /// <param name="types">The nullable value types that you wish to leave as null when building.</param>
+        public static void BuildNullablePropertiesAsNullForType(params Type[] types)
+        {
+            foreach (Type type in types)
+            {
+                if (!type.IsGenericType() || type.GetGenericTypeDefinition() != typeof(Nullable<>))
+                {
+                    throw new ArgumentException($"{type} is not a nullable type.");
+                }
+                Instance.BuildNullableTypeAsNull(type);
+            }
         }
 
         static BuilderSetup()

--- a/src/FizzWare.NBuilder/Fizzware.NBuilder.csproj
+++ b/src/FizzWare.NBuilder/Fizzware.NBuilder.csproj
@@ -8,7 +8,7 @@
     <PackageId>NBuilder</PackageId>
     <Authors>Gareth Down and awesome contributors!</Authors>
     <Description>Through a fluent, extensible interface, NBuilder allows you to rapidly create test data, automatically assigning values to properties and public fields that are one of the built in .NET data types (e.g. ints and strings). NBuilder allows you to override for properties you are interested in using lambda expressions.</Description>
-    <PackageLicenseUrl>http://www.gnu.org/licenses/lgpl.html</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/nbuilder/nbuilder/wiki</PackageProjectUrl>
     <RepositoryUrl>https://github.com/nbuilder/nbuilder</RepositoryUrl>
     <PackageTags>TDD unit-testing unittesting unitesting testing fluent</PackageTags> 

--- a/tests/FizzWare.NBuilder.Tests/TestClasses/MyClass.cs
+++ b/tests/FizzWare.NBuilder.Tests/TestClasses/MyClass.cs
@@ -55,6 +55,7 @@ namespace FizzWare.NBuilder.Tests.TestClasses
 
         public static int StaticInt { get; set; }
 
+        public Guid? NullableGuid { get; set; }
         public int? NullableInt { get; set; }
 
         public int PublicFieldInt;

--- a/tests/FizzWare.NBuilder.Tests/Unit/PropertyNamerTests.cs
+++ b/tests/FizzWare.NBuilder.Tests/Unit/PropertyNamerTests.cs
@@ -56,6 +56,59 @@ namespace FizzWare.NBuilder.Tests.Unit
             myClass.IsSet.ShouldBeFalse();
         }
 
+        [Fact]
+        public void SetValuesOf_BuildAllNullablePropertiesAsNull_DoesntSetTheValueOfNullableProperty()
+        {
+            BuilderSettings builderSettings = new BuilderSettings();
+            BuilderSetup.BuildAllNullablePropertiesAsNull();
+            IReflectionUtil reflectionUtil = Substitute.For<IReflectionUtil>();
+            propertyNamer = new PropertyNamerStub(reflectionUtil, builderSettings);
+
+            MyClass mc = new MyClass { NullableInt = null };
+            
+            propertyNamer.SetValuesOf(mc);
+
+            mc.NullableGuid.HasValue.ShouldBeFalse();
+            mc.NullableInt.HasValue.ShouldBeFalse();
+
+            BuilderSetup.ResetToDefaults();
+        }
+
+        [Fact]
+        public void SetValuesOf_BuildNullablePropertiesAsNullForTypeWithInt_DoesntSetTheValueOfNullableProperty()
+        {
+            BuilderSettings builderSettings = new BuilderSettings();
+            BuilderSetup.BuildNullablePropertiesAsNullForType(typeof(int?));
+            IReflectionUtil reflectionUtil = Substitute.For<IReflectionUtil>();
+            propertyNamer = new PropertyNamerStub(reflectionUtil, builderSettings);
+
+            MyClass mc = new MyClass { NullableInt = null };
+
+            propertyNamer.SetValuesOf(mc);
+
+            mc.NullableInt.HasValue.ShouldBeFalse();
+
+            BuilderSetup.ResetToDefaults();
+        }
+
+        [Fact]
+        public void SetValuesOf_BuildNullablePropertiesAsNullForTypeWithIntAndGuid_DoesntSetTheValueOfNullableProperty()
+        {
+            BuilderSettings builderSettings = new BuilderSettings();
+            BuilderSetup.BuildNullablePropertiesAsNullForType(typeof(int?), typeof(Guid?));
+            IReflectionUtil reflectionUtil = Substitute.For<IReflectionUtil>();
+            propertyNamer = new PropertyNamerStub(reflectionUtil, builderSettings);
+
+            MyClass mc = new MyClass { NullableGuid = null, NullableInt = null };
+
+            propertyNamer.SetValuesOf(mc);
+
+            mc.NullableGuid.HasValue.ShouldBeFalse();
+            mc.NullableInt.HasValue.ShouldBeFalse();
+
+            BuilderSetup.ResetToDefaults();
+        }
+
         private class PropertyNamerStub : PropertyNamer
         {
             public PropertyNamerStub(IReflectionUtil reflectionUtil,BuilderSettings builderSettings) : base(reflectionUtil, builderSettings) { }


### PR DESCRIPTION
* Update license tag since PackageLicenseUrl is deprecated. Also update it to MIT to reflect GitHub license listed.

* Add in support to have a nullable value type built with the value of null instead of the non-null default.
* Support both the scenario of specific nullable value types as well as all nullable value types.

Resolves #86 
Resolves #106 