### PR TITLE
Mark RandomGenerator as Obsolete

### DIFF
--- a/src/FizzWare.NBuilder/Generators/RandomGenerator.cs
+++ b/src/FizzWare.NBuilder/Generators/RandomGenerator.cs
@@ -11,6 +11,7 @@ namespace FizzWare.NBuilder
     // Resharper incorrectly advises that the typecasts are redundant
 
     // ReSharper disable RedundantCast
+    [Obsolete("RandomGenerator will be removed in a future release. Please instead use the GetRandom static class from NBuilder instead.")]
     public class RandomGenerator : IRandomGenerator
     {
         private readonly Random rnd;


### PR DESCRIPTION
Mark RandomGenerator as Obsolete in preparations for removing it in next major release.

Resolves #112 