### PR TITLE
:microscope: Added source-link!

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,12 +65,13 @@
   artifacts:
   - path: NBuilder*.nupkg
     name: nuget-package
+  - path: '**\*.snupkg'
+    name: nuget-symbols
 
   deploy:
     provider: NuGet
     api_key:
       secure: ZW7B2bmgmhp70X5h/WIB3dIcKuo5Tkb1+1gLfviPTEodYsk0lZ69rSy8y7bZ8KgU
-    artifact: nuget-package
 
   before_build:
     - ps: |  
@@ -115,12 +116,13 @@
   artifacts:
   - path: NBuilder*.nupkg
     name: nuget-package
+  - path: '**\*.snupkg'
+    name: nuget-symbols
 
   deploy:
     provider: NuGet
     api_key:
       secure: ZW7B2bmgmhp70X5h/WIB3dIcKuo5Tkb1+1gLfviPTEodYsk0lZ69rSy8y7bZ8KgU
-    artifact: nuget-package
 
   before_build:
     - ps: |  

--- a/src/FizzWare.NBuilder/Fizzware.NBuilder.csproj
+++ b/src/FizzWare.NBuilder/Fizzware.NBuilder.csproj
@@ -17,7 +17,17 @@
     <Company />
     <RepositoryType>Github</RepositoryType>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>NBuilder.snk</AssemblyOriginatorKeyFile> 
+    <AssemblyOriginatorKeyFile>NBuilder.snk</AssemblyOriginatorKeyFile>
+
+     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+     <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+     <IncludeSymbols>true</IncludeSymbols>
+     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6'">
@@ -28,6 +38,10 @@
     <DefineConstants>NET40;NETFULL</DefineConstants>
   </PropertyGroup>
 
+   <ItemGroup>
+       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+   </ItemGroup>
+    
   <ItemGroup>
     <Compile Remove="obj\**" />
     <EmbeddedResource Remove="obj\**" />


### PR DESCRIPTION
Okay - so adding [sourcelink](https://github.com/dotnet/sourcelink) to a library is a great way to easily enable developers to 'step into' the 3rd party library code.

This PR enables this. It's hard to test because it needs a deployment step, but hopefully this is ok/enough.